### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Now you can use these methods like so:
 // for single object
 let json = myModelInstance.serialize('someScheme');
 // for many objects
-let json = MyModel.serialize(instances, 'someScheme');
+let json = MyModel.serializeMany(instances, 'someScheme');
 ```
 
 Of course you can provide the scheme as an object and pass serializer options as the last argument for both methods.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sequelize-to-json",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Serialization of Sequelize models to JSON-compatible objects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Change MyModel.serialze(… to MyModel.serializeMany(… to comply with the example code above.
Bump the version to 0.10.2.