### PR TITLE
Fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ BlogPost.findAll({
   // ...
 }).then(function(posts) {
   // serialize all the items efficiently
-  let postsAsJSON = Serializer.serializeMany(posts, BlogPost, schema);
+  let postsAsJSON = Serializer.serializeMany(posts, BlogPost, scheme);
   
   // serialize just the first item
-  let serializer = new Serializer(BlogPost, schema);
+  let serializer = new Serializer(BlogPost, scheme);
   let postAsJSON = serializer.serialize(posts[0]);
   // ...
 });


### PR DESCRIPTION
The example in the readme uses a non-existent `schema` variable. This should just be `scheme`. 